### PR TITLE
A button in the "post" tab that allows to set starting price and buyout price equally

### DIFF
--- a/tabs/post/core.lua
+++ b/tabs/post/core.lua
@@ -267,7 +267,7 @@ function validate_parameters()
         post_button:Disable()
         return
     end
-    if get_unit_buyout_price() > 0 and get_unit_start_price() > get_unit_buyout_price() then
+    if not start_equals_buyout_checkbox:GetChecked() and get_unit_buyout_price() > 0 and get_unit_start_price() > get_unit_buyout_price() then
         post_button:Disable()
         return
     end

--- a/tabs/post/core.lua
+++ b/tabs/post/core.lua
@@ -198,7 +198,7 @@ end
 
 function post_auctions()
 	if selected_item then
-        local unit_start_price = get_unit_start_price()
+        local unit_start_price = start_equals_buyout_checkbox:GetChecked() and get_unit_buyout_price() or get_unit_start_price()
         local unit_buyout_price = get_unit_buyout_price()
         local stack_size = stack_size_slider:GetValue()
         local stack_count

--- a/tabs/post/core.lua
+++ b/tabs/post/core.lua
@@ -249,55 +249,7 @@ function post_auctions()
 end
 
 function M.post_auctions_bind()
-	if selected_item then
-        local unit_start_price = get_unit_start_price()
-        local unit_buyout_price = get_unit_buyout_price()
-        local stack_size = stack_size_slider:GetValue()
-        local stack_count
-        stack_count = stack_count_slider:GetValue()
-        local duration = UIDropDownMenu_GetSelectedValue(duration_dropdown)
-		local key = selected_item.key
-
-        local duration_code
-		if duration == DURATION_2 then
-            duration_code = 2
-		elseif duration == DURATION_8 then
-            duration_code = 3
-		elseif duration == DURATION_24 then
-            duration_code = 4
-		end
-
-		post.start(
-			key,
-			stack_size,
-			duration,
-            unit_start_price,
-            unit_buyout_price,
-			stack_count,
-			function(posted)
-				if not frame:IsShown() then
-					return
-				end
-				for i = 1, posted do
-                    record_auction(key, stack_size, unit_start_price * stack_size, unit_buyout_price, duration_code, UnitName'player')
-                end
-                update_inventory_records()
-				local same
-                for _, record in inventory_records do
-                    if record.key == key then
-	                    same = record
-	                    break
-                    end
-                end
-                if same then
-	                update_item(same)
-                else
-                    selected_item = nil
-                end
-                refresh = true
-			end
-		)
-	end
+	post_auctions()
 end
 
 function validate_parameters()

--- a/tabs/post/core.lua
+++ b/tabs/post/core.lua
@@ -65,6 +65,16 @@ function refresh_button_click()
 	refresh = true
 end
 
+function update_start_price_visibility()
+    if start_equals_buyout_checkbox:GetChecked() then
+        unit_start_price_input:Hide()
+        start_price_percentage:Hide()
+    else
+        unit_start_price_input:Show()
+        start_price_percentage:Show()
+    end
+end
+
 function tab.OPEN()
     frame:Show()
     update_inventory_records()
@@ -290,7 +300,7 @@ function update_item_configuration()
         hide_checkbox:Hide()
         vendor_price_label:Hide()
     else
-		unit_start_price_input:Show()
+        update_start_price_visibility()
         unit_buyout_price_input:Show()
         stack_size_slider:Show()
         stack_count_slider:Show()

--- a/tabs/post/frame.lua
+++ b/tabs/post/frame.lua
@@ -266,15 +266,7 @@ function aux.handle.INIT_UI()
     do
         local checkbox = gui.checkbox(frame.parameters)
         checkbox:SetPoint('RIGHT', hide_checkbox, 'LEFT', -135, 0)
-        checkbox:SetScript('OnClick', function()
-            if this:GetChecked() then
-                unit_start_price_input:Hide()
-                start_price_percentage:Hide()
-            else
-                unit_start_price_input:Show()
-                start_price_percentage:Show()
-            end
-        end)
+        checkbox:SetScript('OnClick', update_start_price_visibility)
         local label = gui.label(checkbox, gui.font_size.small)
         label:SetPoint('LEFT', checkbox, 'RIGHT', 4, 1)
         label:SetText('Starting = Buyout')

--- a/tabs/post/frame.lua
+++ b/tabs/post/frame.lua
@@ -264,7 +264,14 @@ function aux.handle.INIT_UI()
         hide_checkbox = checkbox
     end
     do
-        local editbox = gui.editbox(frame.parameters)
+        local checkbox = gui.checkbox(frame.parameters)
+        checkbox:SetPoint('RIGHT', hide_checkbox, 'LEFT', -135, 0)
+        local label = gui.label(checkbox, gui.font_size.small)
+        label:SetPoint('LEFT', checkbox, 'RIGHT', 4, 1)
+        label:SetText('Starting = Buyout')
+        start_equals_buyout_checkbox = checkbox
+    end
+    do        local editbox = gui.editbox(frame.parameters)
         editbox:SetPoint('TOPRIGHT', -71, -60)
         editbox:SetWidth(180)
         editbox:SetHeight(22)

--- a/tabs/post/frame.lua
+++ b/tabs/post/frame.lua
@@ -266,6 +266,15 @@ function aux.handle.INIT_UI()
     do
         local checkbox = gui.checkbox(frame.parameters)
         checkbox:SetPoint('RIGHT', hide_checkbox, 'LEFT', -135, 0)
+        checkbox:SetScript('OnClick', function()
+            if this:GetChecked() then
+                unit_start_price_input:Hide()
+                start_price_percentage:Hide()
+            else
+                unit_start_price_input:Show()
+                start_price_percentage:Show()
+            end
+        end)
         local label = gui.label(checkbox, gui.font_size.small)
         label:SetPoint('LEFT', checkbox, 'RIGHT', 4, 1)
         label:SetText('Starting = Buyout')


### PR DESCRIPTION
This will add a checkbox to the "post" auctions tab. The button is unchecked by default. 
Checking the button removes the "Starting price" input box and sets the "Starting price" of auctions to the "Buyout price". This sometimes saves the hustle of copying the buyout price and pasting it into the starting price.

The blocking behavior of the "Post" button in the "post" tab is deactivated on checking this box.
Checking will not persist after relogging/rebooting client. Probably possible to add, i was just too lazy to find the persistence store.

<img width="1358" height="840" alt="starting_buyout_button" src="https://github.com/user-attachments/assets/abf3f42f-c5fe-4b02-96fd-49ff5670c08f" />
