### PR TITLE
Add human readable error fix to error log for autobuy feature

### DIFF
--- a/tabs/search/saved.lua
+++ b/tabs/search/saved.lua
@@ -144,7 +144,7 @@ function enable_auto_buy(search)
 		if getn(queries) > 1 then
 			aux.print('Error: Auto Buy does not support multi-queries')
 		elseif aux.size(queries[1].blizzard_query) > 0 and not filter_util.parse_filter_string(search.filter_string).blizzard.exact then
-			aux.print('Error: Auto Buy does not support Blizzard filters')
+			aux.print('Error: Auto Buy does not support Blizzard filters. It is recommended to match exactly one item via /exact after item name in search command!')
 		else
 			search.auto_buy = true
 		end


### PR DESCRIPTION
The auto buy feature only works on search queries that exactly match an item. The original error log when trying to turn on the auto buy feature is not informing about this. Therefore i extended the error log, which should be sufficient for users to figure out, how to repair their search query.