### PR TITLE
UI changes

### DIFF
--- a/chaux-addon.toc
+++ b/chaux-addon.toc
@@ -1,8 +1,8 @@
 ## Interface: 11200
-## Author: shirsig, chooger
+## Authors: shirsig, chooger
 ## OptionalDeps: ShaguTweaks
-## Title: chaux
-## Notes: Auction House replacement - Chooger Fork
+## Title: Chaux
+## Notes: Auction House replacement - Chooger's Fork
 ## SavedVariables: aux
 
 libs\package.lua

--- a/chaux-addon.toc
+++ b/chaux-addon.toc
@@ -1,8 +1,8 @@
 ## Interface: 11200
-## Author: shirsig
+## Author: shirsig, chooger
 ## OptionalDeps: ShaguTweaks
-## Title: aux
-## Notes: Auction House replacement
+## Title: chaux
+## Notes: Auction House replacement - Chooger Fork
 ## SavedVariables: aux
 
 libs\package.lua

--- a/core/disenchant.lua
+++ b/core/disenchant.lua
@@ -33,6 +33,23 @@ local WEAPON = T.set(
 	'INVTYPE_RANGEDRIGHT'
 )
 
+local CUSTOM_DISTRIBUTIONS = {
+    -- [Gardening Gloves] modified by TurtleWoW Survival overhaul.
+    [42095] = function()
+        return T.temp-T.list(
+            T.temp-T.map('item_id', 10940, 'min_quantity', 1, 'max_quantity', 2, 'probability', .8),
+            T.temp-T.map('item_id', 10938, 'min_quantity', 1, 'max_quantity', 2, 'probability', .2)
+        )
+    end,
+    -- [Woolen Cape] modified by TurtleWoW.
+    [2584] = function()
+        return T.temp-T.list(
+            T.temp-T.map('item_id', 10940, 'min_quantity', 1, 'max_quantity', 2, 'probability', .8),
+            T.temp-T.map('item_id', 10938, 'min_quantity', 1, 'max_quantity', 2, 'probability', .2)
+        )
+    end,
+}
+
 function M.value(slot, quality, level, item_id)
     local expectation
     for _, event in distribution(slot, quality, level, item_id) do
@@ -50,6 +67,11 @@ function M.value(slot, quality, level, item_id)
 end
 
 function M.distribution(slot, quality, level, item_id)
+    local custom = CUSTOM_DISTRIBUTIONS[item_id]
+    if custom then
+        return custom()
+    end
+
     if not ARMOR[slot] and not WEAPON[slot] or level == 0 then
         return T.acquire()
 	elseif --special items not following general rules

--- a/gui/core.lua
+++ b/gui/core.lua
@@ -11,80 +11,6 @@ M.font_size = aux.immutable-{
 	large = 18,
 }
 
---function aux.handle.LOAD()
---	do
---		local blizzard_backdrop, aux_background, aux_border
---
---		aux_border = DropDownList1:CreateTexture()
---		aux_border:SetTexture(1, 1, 1, .02)
---		aux_border:SetPoint('TOPLEFT', DropDownList1Backdrop, 'TOPLEFT', -2, 2)
---		aux_border:SetPoint('BOTTOMRIGHT', DropDownList1Backdrop, 'BOTTOMRIGHT', 1.5, -1.5)
---		aux_border:SetBlendMode('ADD')
---		aux_background = DropDownList1:CreateTexture(nil, 'OVERLAY')
---		aux_background:SetTexture(aux.color.content.background())
---		aux_background:SetAllPoints(DropDownList1Backdrop)
---		blizzard_backdrop = DropDownList1Backdrop:GetBackdrop()
---		aux.hook('ToggleDropDownMenu', function(...)
---			T.temp(arg)
---			local ret = T.temp-T.list(aux.orig.ToggleDropDownMenu(unpack(arg)))
---			local dropdown = _G[arg[4] or ''] or this:GetParent()
---			if strfind(dropdown:GetName() or '', '^aux.frame%d+$') then
---				set_aux_dropdown_style(dropdown)
---			else
---				set_blizzard_dropdown_style()
---			end
---			return unpack(ret)
---		end)
---
---		function set_aux_dropdown_style(dropdown)
---			DropDownList1Backdrop:SetBackdrop(T.empty)
---			aux_border:Show()
---			aux_background:Show()
---			DropDownList1:SetWidth(dropdown:GetWidth() * .9)
---			DropDownList1:SetHeight(DropDownList1:GetHeight() - 10)
---			DropDownList1:ClearAllPoints()
---			DropDownList1:SetPoint('TOPLEFT', dropdown, 'BOTTOMLEFT', -2, -2)
---			for i = 1, UIDROPDOWNMENU_MAXBUTTONS do
---				local button = _G['DropDownList1Button' .. i]
---				button:SetPoint('TOPLEFT', 0, -((button:GetID() - 1) * UIDROPDOWNMENU_BUTTON_HEIGHT) - 7)
---				button:SetPoint('TOPRIGHT', 0, -((button:GetID() - 1) * UIDROPDOWNMENU_BUTTON_HEIGHT) - 7)
---				local text = button:GetFontString()
---				text:SetFont(font, 14)
---				text:SetPoint('TOPLEFT', 18, 0)
---				text:SetPoint('BOTTOMRIGHT', -8, 0)
---				local highlight = _G['DropDownList1Button' .. i .. 'Highlight']
---				highlight:ClearAllPoints()
---				highlight:SetDrawLayer('OVERLAY')
---				highlight:SetHeight(14)
---				highlight:SetPoint('LEFT', 5, 0)
---				highlight:SetPoint('RIGHT', -3, 0)
---				local check = _G['DropDownList1Button' .. i .. 'Check']
---				check:SetWidth(16)
---				check:SetHeight(16)
---				check:SetPoint('LEFT', 3, -1)
---			end
---		end
---
---		function set_blizzard_dropdown_style()
---			DropDownList1Backdrop:SetBackdrop(blizzard_backdrop)
---			aux_border:Hide()
---			aux_background:Hide()
---			for i = 1, UIDROPDOWNMENU_MAXBUTTONS do
---				local button = _G['DropDownList1Button' .. i]
---				local text = button:GetFontString()
---				text:SetFont([[Fonts\FRIZQT__.ttf]], 10)
---				text:SetShadowOffset(1, -1)
---				local highlight = _G['DropDownList1Button' .. i .. 'Highlight']
---				highlight:SetAllPoints()
---				highlight:SetDrawLayer('BACKGROUND')
---				local check = _G['DropDownList1Button' .. i .. 'Check']
---				check:SetWidth(24)
---				check:SetHeight(24)
---				check:SetPoint('LEFT', 0, 0)
---			end
---		end
---	end
---end
 
 do
 	local id = 1
@@ -585,7 +511,7 @@ function M.item(parent)
     btn:RegisterForClicks()
     item.texture = _G[btn:GetName() .. 'Icon']
     item.texture:SetTexCoord(.06, .94, .06, .94)
-    item.name = label(btn, font_size.medium)
+    item.name = label(btn, font_size.large)
     item.name:SetJustifyH('LEFT')
     item.name:SetPoint('LEFT', btn, 'RIGHT', 10, 0)
     item.name:SetPoint('RIGHT', item, 'RIGHT', -10, .5)

--- a/gui/item_listing.lua
+++ b/gui/item_listing.lua
@@ -5,7 +5,8 @@ local aux = require 'aux'
 local info = require 'aux.util.info'
 local gui = require 'aux.gui'
 
-local ROW_HEIGHT = 39
+-- CHANGE: was 39    v
+local ROW_HEIGHT = 30
 
 function M:render()
 
@@ -86,7 +87,8 @@ function M.new(parent, on_click, selected)
 		end)
 
 		row.item = gui.item(row)
-		row.item:SetScale(.9)
+		-- CHANGED: was '.9'
+		row.item:SetScale(ROW_HEIGHT/(13/0.3))
 		row.item:SetPoint('LEFT', 2.5, 0)
 		row.item:SetPoint('RIGHT', -2.5, 0)
 		row.item.button:SetScript('OnEnter', function()

--- a/gui/item_listing.lua
+++ b/gui/item_listing.lua
@@ -5,7 +5,8 @@ local aux = require 'aux'
 local info = require 'aux.util.info'
 local gui = require 'aux.gui'
 
-local ROW_HEIGHT = 39
+-- CHANGE: was 39    v
+local ROW_HEIGHT = 29
 
 function M:render()
 
@@ -86,7 +87,8 @@ function M.new(parent, on_click, selected)
 		end)
 
 		row.item = gui.item(row)
-		row.item:SetScale(.9)
+		-- CHANGED: was '.9'
+		row.item:SetScale(ROW_HEIGHT/(13/0.3)) -- This formula keeps item icon proportional to row_height
 		row.item:SetPoint('LEFT', 2.5, 0)
 		row.item:SetPoint('RIGHT', -2.5, 0)
 		row.item.button:SetScript('OnEnter', function()

--- a/gui/purchase_summary.lua
+++ b/gui/purchase_summary.lua
@@ -147,7 +147,7 @@ function M.update_display()
 		-- Create new row frame if needed
 		if not frame.rows[row_count] then
 			local row = CreateFrame('Frame', nil, frame)
-			row:SetHeight(14)
+			row:SetHeight(13)  -- Reduced to 13 from 14 to condense summary.
 			row:SetWidth(260)  -- Reduced width
 
 			-- Item name column
@@ -206,7 +206,7 @@ function M.update_display()
 	end
 
 	-- Resize frame to fit content
-	local estimated_height = 44 + (row_count * 14)  -- Header + rows with reduced padding
+	local estimated_height = 44 + (row_count * 13)  -- Header + rows with reduced padding; Changed from 14 to 13 to account for row height reduction.
 	frame:SetHeight(math.max(60, estimated_height))
 
 	frame:Show()

--- a/gui/purchase_summary.lua
+++ b/gui/purchase_summary.lua
@@ -141,7 +141,7 @@ function M.update_display()
 
 	-- Create rows for each item
 	local row_count = 0
-	for item_name, summary in purchase_summaries do
+	for item_name, summary in pairs(purchase_summaries) do
 		row_count = row_count + 1
 
 		-- Create new row frame if needed
@@ -150,17 +150,26 @@ function M.update_display()
 			row:SetHeight(13)  -- Reduced to 13 from 14 to condense summary.
 			row:SetWidth(260)  -- Reduced width
 
+			-- Item icon column
+			local icon = row:CreateTexture(nil, 'OVERLAY')
+			icon:SetPoint("TOPLEFT", row, "TOPLEFT", 0, 0)
+			icon:SetWidth(13)
+			icon:SetHeight(13)
+			icon:SetTexture(texture)
+			icon:SetTexCoord(.08, .92, .08, .92)
+			row.icon = icon
+
 			-- Item name column
 			local item_text = row:CreateFontString(nil, 'OVERLAY', 'GameFontNormal')
-			item_text:SetPoint('TOPLEFT', row, 'TOPLEFT', 0, 0)
-			item_text:SetWidth(150)
+			item_text:SetPoint('TOPLEFT', row, 'TOPLEFT', 15, 0)  -- 13 + 2 spacing for icon
+			item_text:SetWidth(135)
 			item_text:SetJustifyH('LEFT')
 			item_text:SetTextColor(aux.color.text.enabled())
 			row.item_text = item_text
 
 			-- Count column
 			local count_text = row:CreateFontString(nil, 'OVERLAY', 'GameFontNormal')
-			count_text:SetPoint('TOPLEFT', row, 'TOPLEFT', 155, 0)  -- 150 + 5 spacing
+			count_text:SetPoint('TOPLEFT', row, 'TOPLEFT', 155, 0)  -- 15 + 135 + 5 spacing
 			count_text:SetWidth(40)
 			count_text:SetJustifyH('RIGHT')
 			count_text:SetTextColor(aux.color.text.enabled())
@@ -189,6 +198,9 @@ function M.update_display()
 		-- Set the text content
 		row.item_text:SetText(item_name)
 		row.count_text:SetText(summary.total_quantity .. 'x')
+
+		-- Set the icon texture
+		row.icon:SetTexture(summary.texture)
 
 		-- Drop copper when displaying gold amounts
 		local cost = summary.total_cost or 0


### PR DESCRIPTION
**UI:**
- Post tab item listings have been made smaller overall, but the icon enlarged; you can see more listings without scrolling.
- Purchase summary condensed to show more listings before running off screen. Will make scroll-able in the future.
- Purchase summaries now has item icons.

**Backend:**
- Custom disenchant table/exceptions added to aux enchant-value/distribution tooltips calculations. This is just the supporting code, have not fully populated all new custom item disenchants. 
- Populated new custom disenchant distribution table with Woolen Cloak and Gardening Gloves; in other words, these items now show the correct disenchant value and distribution in tooltips.